### PR TITLE
Fix TypeError: ensure CLIP image features return a Tensor

### DIFF
--- a/geoclip/model/image_encoder.py
+++ b/geoclip/model/image_encoder.py
@@ -23,6 +23,7 @@ class ImageEncoder(nn.Module):
         return x
 
     def forward(self, x):
-        x = self.CLIP.get_image_features(pixel_values=x)
+        output = self.CLIP.get_image_features(pixel_values=x)
+        x = output if isinstance(output, torch.Tensor) else output.pooler_output
         x = self.mlp(x)
         return x


### PR DESCRIPTION
The get_image_features method in certain versions of the CLIP model (Hugging Face Transformers) returns a BaseModelOutputWithPooling object instead of a raw torch.Tensor. This causes a TypeError when the output is passed directly to downstream linear layers or projection heads.